### PR TITLE
Xsecbias fix

### DIFF
--- a/src/pybdsim/XSecBias.py
+++ b/src/pybdsim/XSecBias.py
@@ -4,7 +4,13 @@ _allowedparticles = frozenset([
     'e-',
     'e+',
     'proton',
-    'gamma'
+    'gamma',
+    'pi+',
+    'pi-',
+    'kaon+',
+    'kaon-',
+    'mu+',
+    'mu-'
 ])
 
 _allowedflags = frozenset([

--- a/src/pybdsim/XSecBias.py
+++ b/src/pybdsim/XSecBias.py
@@ -1,18 +1,5 @@
 from re import split as _split
 
-_allowedparticles = frozenset([
-    'e-',
-    'e+',
-    'proton',
-    'gamma',
-    'pi+',
-    'pi-',
-    'kaon+',
-    'kaon-',
-    'mu+',
-    'mu-'
-])
-
 _allowedflags = frozenset([
     '1',
     '2',
@@ -26,7 +13,7 @@ class XSecBias(object):
     """
     def __init__(self, name, particle, processes, xsecfactors, flags):
         self.name        = self.SetName(name)
-        self.particle    = self.SetParticle(particle)
+        self.particle    = particle
         self.processlist = self.SetProcesses(processes)
         self.flaglist    = self.SetFlags(flags)
         self.xseclist    = self.SetXSecFactors(xsecfactors)
@@ -40,15 +27,6 @@ class XSecBias(object):
         if name.lower() == 'xsecbias':
             raise ValueError("Forbidden name: "+ str(name) +".  Bias name cannot be any variant of 'xsecbias' (case insensitive)")
         return name
-
-    def SetParticle(self, particle):
-        """
-        Set the particle for bias to be associated with.
-        """
-        if particle  in _allowedparticles:
-            return particle
-        else:
-            raise ValueError("Unknown Particle type: " + str(particle) + ".")
 
     def SetProcesses(self, processes):
         '''


### PR DESCRIPTION
Added more particles to XSecBias so that the assert is not triggered, the list was short and did not cover muons, pions, kaons, which we frequently want to cross-section bias.

(other changes were already dealt with in separate pull-request)